### PR TITLE
Account for all error statuses for error messaging

### DIFF
--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -58,16 +58,16 @@ const LoginForm = (props: any) => {
         } 
         setUsers(users);
       }
+      else {
+        setErrorMessage('Invalid login');
+      }
     } catch (e: any) {
       console.log(e)
-      const status = e.response.status;
       if (e.code === 'ERR_NETWORK') {
         setErrorMessage('Network Error');
       } 
       else {
-        if (status === 400) {
           setErrorMessage('Invalid login');
-        }
       }     
    }
   }


### PR DESCRIPTION
Removed logic to only handle 400 status error code to account for all error codes
<img width="584" alt="Screenshot 2023-02-26 at 10 48 03 AM" src="https://user-images.githubusercontent.com/46292569/221420966-a8532c06-f67a-4427-abd4-1b13d09a3ee9.png">
<img width="720" alt="Screenshot 2023-02-26 at 10 40 16 AM" src="https://user-images.githubusercontent.com/46292569/221420970-4ef527cd-1a0c-4f99-9e65-6b53a4893d43.png">
