### PR TITLE
Update links for react-router-dom/fix active banner

### DIFF
--- a/src/components/gamepage/UserAccount.tsx
+++ b/src/components/gamepage/UserAccount.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import {useNavigate} from 'react-router-dom';
 
 //Components
 import Box from "@mui/material/Box";
@@ -22,6 +23,7 @@ const UserAccount = (props: any) => {
   const [password, setPassword] = useState('');
   const [isUpdated, setIsUpdated] = useState(false);
 
+  const navigate = useNavigate()
 
   const handleSubmit = async (e: any) => {
     e.preventDefault();
@@ -57,6 +59,10 @@ const UserAccount = (props: any) => {
     }
   }
 
+  const handleGamePageClick = () => {
+    navigate('/gamepage');
+  }
+
   return (
     <UserAccountContainer>
       <h3>Account Info</h3>
@@ -83,7 +89,7 @@ const UserAccount = (props: any) => {
       <ButtonContainer>
       <Button variant="contained" type="submit">Update Info</Button>
       {isUpdated ? (<p>Account Info Updated</p>): null}
-      <Button color="success" href="/">
+      <Button color="success" onClick={handleGamePageClick}>
             Go to Game Page
           </Button>
       </ButtonContainer>

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -30,7 +30,6 @@ const LoginForm = (props: any) => {
         username,
         password
       })
-      console.log(response);
       if (response.status === 201) {
         setUsername('')
         setPassword('')

--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -52,6 +52,10 @@ const NavBar = (props: any) => {
     navigate(route);
   }
 
+  const handleIconClick = () => {
+    navigate('/')
+  }
+
   return (
     <AppBarContainer position="fixed">
       <Container maxWidth="xl">
@@ -60,7 +64,7 @@ const NavBar = (props: any) => {
             variant="h6"
             noWrap
             component="a"
-            href="/"
+            onClick={handleIconClick}
             sx={{
               mr: 2,
               display: { xs: 'none', md: 'flex' },
@@ -123,7 +127,7 @@ const NavBar = (props: any) => {
             variant="h5"
             noWrap
             component="a"
-            href="/"
+            onClick={handleIconClick}
             sx={{
               mr: 2,
               display: { xs: 'flex', md: 'none' },

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -19,7 +19,7 @@ export default function GamePage(props: any) {
 
   return (
     <GamePageContainer>
-      <h1>ACTIVE</h1>
+      {user.isactive? (<h1>ACTIVE</h1>) : <h1 style={{color: 'grey'}}>INACTIVE</h1>}
       <CurrentActivePlayers users={users}/>
       <GamePageComponents>
         <Section>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,3 +1,5 @@
+import {useNavigate} from 'react-router-dom';
+
 //Components
 import Button from "@mui/material/Button";
 import LeaderBoard from "../components/LeaderBoard";
@@ -7,6 +9,12 @@ import { LandingPageContainer, LandingPageSection } from "./LandingPage.styles";
 
 
 const LandingPage = () => {
+  const navigate = useNavigate();
+
+  const handleClick = (route: string) => {
+    navigate(route)
+  }
+
   return (
     <LandingPageContainer>
       <LandingPageSection>
@@ -17,10 +25,10 @@ const LandingPage = () => {
           <LeaderBoard />
         </div>
         <div className="loginButton">
-          <Button variant="contained" color="success" href="/login">
+          <Button variant="contained" color="success" onClick={e => handleClick('/login')}>
             GO TO LOGIN
           </Button>
-          <Button variant="contained" color="success" href="/register">
+          <Button variant="contained" color="success" onClick={e => handleClick('/register')}>
             GO TO REGISTER
           </Button>
         </div>


### PR DESCRIPTION
Updated links to use navigate for react-router-dom.  Remove hardcoded ACTIVE banner and made conditional.

<img width="592" alt="Screenshot 2023-02-26 at 7 05 49 PM" src="https://user-images.githubusercontent.com/46292569/221445867-4c396fc7-416f-47c3-9452-3111888dc917.png">

![Screenshot 2023-02-26 at 7 06 17 PM](https://user-images.githubusercontent.com/46292569/221445872-1824764b-fe96-4c85-ae80-41b43649061a.png)
